### PR TITLE
fix: emit variable declaration in ascending order

### DIFF
--- a/src/emitter/yinyang_emitter.py
+++ b/src/emitter/yinyang_emitter.py
@@ -33,7 +33,7 @@ def emit(tree: Operator, file, is_symbolic: bool = True):
     print("#begin", file=file)
 
     # Variable declarations
-    for variable, type in variables.items():
+    for variable, type in sorted(variables.items()):
         print(f"(declare-const {variable} {type})", file=file)
 
     # Constant declarations


### PR DESCRIPTION
To stick with yinyang order of variable declaration, we emit them in ascending order. I think it doesn't make any difference as those declare commands are not taken into consideration in yinyang in my understanding.