### PR TITLE
test: add generation of operators in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Generate operators
+        run:
+          python src/gen/generator.py operators
       - name: Run unittest
         run:
           python -m unittest discover -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Run unittest on published code
+        run:
+          python -m unittest discover -v
       - name: Generate operators
         run:
           python src/gen/generator.py operators
-      - name: Run unittest
+      - name: Run unittest on auto generated operators
         run:
           python -m unittest discover -v

--- a/src/gen/generator.py
+++ b/src/gen/generator.py
@@ -72,6 +72,7 @@ def define_generic(output_dir: pathlib.Path, license: str):
     path = output_dir.joinpath("generic.py")
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, 'w+', encoding='utf-8') as f:
+        print(f"...emitting base classes to {path.as_uri()}")
         f.write(license + "\n")
         f.write("\n".join([
             WARNING_MESSAGE,
@@ -187,6 +188,7 @@ def define_ast(base_name: pathlib.Path, license: str):
         ])
         content.extend(define_visitor_interface(theory))
         with open(path, 'w+', encoding='utf-8') as f:
+            print(f"...emitting operators and visitor interface for {theory} to {path.as_uri()}")
             f.write("\n".join(content))
 
 
@@ -252,6 +254,7 @@ def main():
     # Ensure that the 'operators' folder exists.
     os.makedirs(os.path.dirname(script_path), exist_ok=True)
 
+    print("Generate src/operators directory:")
     define_generic(output_dir, license)
     define_ast(output_dir, license)
 

--- a/src/gen/generator.py
+++ b/src/gen/generator.py
@@ -1,17 +1,17 @@
 # MIT License
-# 
+#
 # Copyright (c) 2022 Nicola Dardanis, Lucas Weitzendorf
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -109,7 +109,8 @@ def define_visitor_interface(theory: str) -> List[str]:
     ])
     for operator in [*get_operators(theory), get_variable(theory), get_constant(theory), get_root(theory)]:
         content.append(f"    @abstractmethod")
-        content.append(f"    def visit_{camel_to_snake_case(operator)}(self, operator: {operator}):")
+        content.append(
+            f"    def visit_{camel_to_snake_case(operator)}(self, operator: {operator}):")
         content.append(f"        pass")
         content.append(f"")
     return content
@@ -188,7 +189,8 @@ def define_ast(base_name: pathlib.Path, license: str):
         ])
         content.extend(define_visitor_interface(theory))
         with open(path, 'w+', encoding='utf-8') as f:
-            print(f"...emitting operators and visitor interface for {theory} to {path.as_uri()}")
+            print(
+                f"...emitting operators and visitor interface for {theory} to {path.as_uri()}")
             f.write("\n".join(content))
 
 
@@ -211,7 +213,8 @@ def define_visitor(output_dir: pathlib.Path, name: str, license: str):
         visitor_name = f"{get_theory_name(theory)}Visitor"
         extends.append(f"{visitor_name}")
 
-        content.append(f"from src.operators.{get_module_name(theory)} import (")
+        content.append(
+            f"from src.operators.{get_module_name(theory)} import (")
         for operator in [*get_operators(theory), get_variable(theory), get_constant(theory), get_root(theory)]:
             content.append(f"    {operator},")
         content.append(f"    {visitor_name}")
@@ -225,7 +228,8 @@ def define_visitor(output_dir: pathlib.Path, name: str, license: str):
     ])
     for theory in get_theories():
         for operator in [*get_operators(theory), get_variable(theory), get_constant(theory), get_root(theory)]:
-            content.append(f"    def visit_{camel_to_snake_case(operator)}(self, operator: {operator}):")
+            content.append(
+                f"    def visit_{camel_to_snake_case(operator)}(self, operator: {operator}):")
             content.append(f"        pass")
             content.append(f"")
     with open(path, 'w+', encoding='utf-8') as f:
@@ -260,7 +264,8 @@ def main():
 
     print(sys.argv[1])
     if sys.argv[1] == "stub":
-        define_visitor(script_path.parent.joinpath("visitors"), sys.argv[2], license)
+        define_visitor(script_path.parent.joinpath(
+            "visitors"), sys.argv[2], license)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I have added a last commit where I just used autopep8 to format the code automatically. Let me know if this is ok and if we can use it as our formatter. The best would be to have a linter, that is capable of detecting more stuff, like unused imports, I have been reading about Flake8. The only thing, I am not sure if this integrates nicely with PyCharm or if it conflicts