### PR TITLE
feat: build Docker image every day once

### DIFF
--- a/.github/workflows/publish_docker_ondemand.yml
+++ b/.github/workflows/publish_docker_ondemand.yml
@@ -5,7 +5,10 @@
 
 name: Publish Docker image
 
-on: workflow_dispatch
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '14 3 * * *'
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
Github will build automatically the image every day, we can also manually trigger if needed.