### PR TITLE
fix: make generator code compatible with python 3.8

### DIFF
--- a/ffg/gen/tree_generation.py
+++ b/ffg/gen/tree_generation.py
@@ -41,7 +41,7 @@ from ffg.visitors.initialization_visitor import InitializationVisitor
 constant_name_pattern = re.compile(r"^c\d+$")
 
 
-def generate_tree(theory: str, size: int, in_variables: Union[int, List[str]], out_variable: str) -> tuple[Any, int]:
+def generate_tree(theory: str, size: int, in_variables: Union[int, List[str]], out_variable: str) -> Tuple[Any, int]:
     if isinstance(in_variables, int):
         in_variables = [f'x{i+1}' for i in range(in_variables)]
     else:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,9 @@
+import unittest
+
+from ffg.gen.tree_generation import generate_tree
+
+
+class TestRegressions(unittest.TestCase):
+    def testGeneratorCompatibility(self):
+        # it is sufficient to parse the code to replicate the issue.
+        pass


### PR DESCRIPTION
The CI of YinYang is failing due to a compatibility issue. Our CI didn't spot the problem as we are not having any tests using the generator algorithm, we should probably add some.

I added a stupid regression test for now to avoid the same bug again